### PR TITLE
sqlite 3.37.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.36.0" %}
+{% set version = "3.37.0" %}
 {% set year = "2021" %}
 {% set version_split = version.split(".") %}
 {% set major = version_split[0] %}
@@ -12,7 +12,7 @@ package:
 
 source:
   url: https://www.sqlite.org/{{ year }}/sqlite-autoconf-{{ version_coded }}.tar.gz
-  sha256: bd90c3eb96bee996206b83be7065c9ce19aef38c3f4fb53073ada0d0b69bbce3
+  sha256: 731a4651d4d4b36fc7d21db586b2de4dd00af31fd54fb5a9a4b7f492057479f7
   patches:
     - expose_symbols.patch  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,8 @@ requirements:
     - {{ compiler('c') }}
     - make  # [not win]
     - libtool  # [not win]
+    - m2-patch  # [win]
+    - patch  # [not win]
   host:
     - ncurses  # [not win]
     - readline  # [not win]
@@ -52,7 +54,7 @@ test:
 
 about:
   home: http://www.sqlite.org/
-  license: Public-Domain (http://www.sqlite.org/copyright.html)
+  license: Unlicense
   license_url: http://www.sqlite.org/copyright.html
   summary: Implements a self-contained, zero-configuration, SQL database engine
   description: |
@@ -61,7 +63,7 @@ about:
     in the world.
   doc_url: http://www.sqlite.org/docs.html
   doc_source_url: https://github.com/mackyle/sqlite/tree/master/doc
-  dev_url: https://github.com/mackyle/sqlite
+  dev_url: https://sqlite.org/src/dir?ci=trunk
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Update sqlite to 3.37.0

Version change: bump version number from 3.36.0 to 3.37.0
Requirements from conda-forge: https://github.com/conda-forge/sqlite-feedstock/blob/master/recipe/meta.yaml
dev_url: https://sqlite.org/src/dir?ci=trunk

The package sqlite is mentioned inside the packages:
cyrus-sasl | fossil | gdal | gdal-2.3.0 | ibis-framework | libspatialite | lighttpd | nss | proj.4 | proj.4-6.2.1 | proj.4-7.2.0 | python | python-2.7 | python-2.7.13 | python-3.5 | python-3.6 | python-3.7 | python-3.8 | python-3.9 | qt | qt-5.11 | qt-5.12 | qt-5.6 | sqlalchemy | sqlalchemy-1.3.13 | sqlalchemy-jsonfield | sqlite | svn | vtk |


Actions:
1. Fix license
2. Fix dev_url: `https://sqlite.org/src/dir?ci=trunk`
3. Add (m2)-patch

Result:
- all-succeeded