### PR TITLE
sqlite 3.37.2

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,6 +22,9 @@ export CPPFLAGS="${CPPFLAGS} -DSQLITE_ENABLE_COLUMN_METADATA=1 \
                              -DSQLITE_ENABLE_FTS5 \
                              -DSQLITE_ENABLE_RTREE=1"
 
+if [[ $target_platform =~ linux.* ]]; then
+    export CFLAGS="${CFLAGS} -DHAVE_PREAD64 -DHAVE_PWRITE64"
+fi
 
 if [[ "$target_platform" == "linux-ppc64le" ]]; then
     export PPC64LE="--build=ppc64le-linux"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,35 +22,33 @@ build:
     # sometimes adds new symbols.  Default behavior is OK.
     #    https://abi-laboratory.pro/tracker/timeline/sqlite/
     - {{ pin_subpackage('sqlite') }}
-  ignore_run_exports:
-    - ncurses 
 
 requirements:
   build:
     - {{ compiler('c') }}
-    - make  # [not win]
-    - libtool  # [not win]
+    - make      # [not win]
+    - libtool   # [not win]
     - m2-patch  # [win]
-    - patch  # [not win]
+    - patch     # [not win]
   host:
-    - ncurses  # [not win]
+    - ncurses   # [not win]
     - readline  # [not win]
-    - zlib  # [not win]
+    - zlib      # [not win]
   run:
     - readline  # [not win]
-    - zlib  # [not win]
+    - zlib      # [not win]
 
 test:
   commands:
     - sqlite3 --version
-    - if not exist %PREFIX%\\Library\bin\sqlite3.dll exit 1  # [win]
-    - if not exist %PREFIX%\\Library\lib\sqlite3.lib exit 1  # [win]
-    - test -f $PREFIX/lib/libsqlite3${SHLIB_EXT}  # [not win]
-    - test ! -f $PREFIX/lib/libsqlite3.a  # [not win]
-    - if not exist %PREFIX%\\Library\include\sqlite3.h exit 1  # [win]
+    - if not exist %PREFIX%\\Library\bin\sqlite3.dll exit 1       # [win]
+    - if not exist %PREFIX%\\Library\lib\sqlite3.lib exit 1       # [win]
+    - test -f $PREFIX/lib/libsqlite3${SHLIB_EXT}                  # [not win]
+    - test ! -f $PREFIX/lib/libsqlite3.a                          # [not win]
+    - if not exist %PREFIX%\\Library\include\sqlite3.h exit 1     # [win]
     - if not exist %PREFIX%\\Library\include\sqlite3ext.h exit 1  # [win]
-    - test -f $PREFIX/include/sqlite3.h  # [not win]
-    - test -f $PREFIX/include/sqlite3ext.h  # [not win]
+    - test -f $PREFIX/include/sqlite3.h                           # [not win]
+    - test -f $PREFIX/include/sqlite3ext.h                        # [not win]
 
 about:
   home: http://www.sqlite.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.37.0" %}
+{% set version = "3.37.2" %}
 {% set year = "2021" %}
 {% set version_split = version.split(".") %}
 {% set major = version_split[0] %}
@@ -12,7 +12,7 @@ package:
 
 source:
   url: https://www.sqlite.org/{{ year }}/sqlite-autoconf-{{ version_coded }}.tar.gz
-  sha256: 731a4651d4d4b36fc7d21db586b2de4dd00af31fd54fb5a9a4b7f492057479f7
+  sha256: 733712712a0d9c9e1197ceb2f55a93497ba46168548a66ef1b039f3fe6b140b6
   patches:
     - expose_symbols.patch  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ test:
     - test -f $PREFIX/include/sqlite3ext.h                        # [not win]
 
 about:
-  home: http://www.sqlite.org/
+  home: https://www.sqlite.org/
   license: Unlicense
   license_url: http://www.sqlite.org/copyright.html
   summary: Implements a self-contained, zero-configuration, SQL database engine
@@ -61,7 +61,7 @@ about:
     SQLite is a self-contained, high-reliability, embedded, full-featured,
     public-domain, SQL database engine.It is the most used database engine
     in the world.
-  doc_url: http://www.sqlite.org/docs.html
+  doc_url: https://www.sqlite.org/docs.html
   doc_source_url: https://github.com/mackyle/sqlite/tree/master/doc
   dev_url: https://sqlite.org/src/dir?ci=trunk
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ package:
 
 source:
   url: https://www.sqlite.org/{{ year }}/sqlite-autoconf-{{ version_coded }}.tar.gz
-  sha256: 733712712a0d9c9e1197ceb2f55a93497ba46168548a66ef1b039f3fe6b140b6
+  sha256: 4089a8d9b467537b3f246f217b84cd76e00b1d1a971fe5aca1e30e230e46b2d8
   patches:
     - expose_symbols.patch  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.37.2" %}
-{% set year = "2021" %}
+{% set year = "2022" %}
 {% set version_split = version.split(".") %}
 {% set major = version_split[0] %}
 {% set minor = version_split[1]|int * 10 %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,8 @@ build:
     # sometimes adds new symbols.  Default behavior is OK.
     #    https://abi-laboratory.pro/tracker/timeline/sqlite/
     - {{ pin_subpackage('sqlite') }}
+  ignore_run_exports:
+    - ncurses 
 
 requirements:
   build:


### PR DESCRIPTION
Update sqlite to 3.37.2

Version change: bump version number from 3.37.0 to 3.37.2
Requirements from conda-forge: https://github.com/conda-forge/sqlite-feedstock/blob/master/recipe/meta.yaml
dev_url: https://sqlite.org/src/dir?ci=trunk

Actions:
1. Add pread64 CFLAGS in `build.sh` (align with conda-forge recipe https://github.com/conda-forge/sqlite-feedstock/commit/05ca616665cb40669322fb1f21a2b822e0c0c6fb)
2. Update year
3. Align left selectors for readability 

Result:
- all-succeeded