### PR TITLE
Update sqlite from 3.38.3 to 3.38.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.38.3" %}
+{% set version = "3.38.5" %}
 {% set year = "2022" %}
 {% set version_split = version.split(".") %}
 {% set major = version_split[0] %}
@@ -12,7 +12,7 @@ package:
 
 source:
   url: https://www.sqlite.org/{{ year }}/sqlite-autoconf-{{ version_coded }}.tar.gz
-  sha256: 61f2dd93a2e38c33468b7125967c3218bf9f4dd8365def6025e314f905dc942e
+  sha256: 5af07de982ba658fd91a03170c945f99c971f6955bc79df3266544373e39869c
   patches:
     - expose_symbols.patch  # [win]
 


### PR DESCRIPTION
## Changes
Update version from 3.38.3 to 3.38.5.

## Package Info
Home: https://www.sqlite.org/
Source: https://sqlite.org/src/dir?ci=trunk
Changelog: https://www.sqlite.org/changes.html
Downloads: 3788321 
Last upload: 1 month and 8 days ago

## Test Status
Passed