### PR TITLE
Update sqlite from 3.38.5 to 3.39.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.38.5" %}
+{% set version = "3.39.0" %}
 {% set year = "2022" %}
 {% set version_split = version.split(".") %}
 {% set major = version_split[0] %}
@@ -12,7 +12,7 @@ package:
 
 source:
   url: https://www.sqlite.org/{{ year }}/sqlite-autoconf-{{ version_coded }}.tar.gz
-  sha256: 5af07de982ba658fd91a03170c945f99c971f6955bc79df3266544373e39869c
+  sha256: e90bcaef6dd5813fcdee4e867f6b65f3c9bfd0aec0f1017f9f3bbce1e4ed09e2
   patches:
     - expose_symbols.patch  # [win]
 


### PR DESCRIPTION
## Changes
Update version from 3.38.5 to 3.39.0.

## Package Info
Home: https://www.sqlite.org/
Source: https://sqlite.org/src/dir?ci=trunk
Changelog: https://www.sqlite.org/changes.html
Bug Tracker: https://www.sqlite.org/src/rptview?rn=1
Downloads: 4024736
Last upload: 10 days and 22 hours ago

## Verifications
License is SPDX compliant
`doc_url` is correct
`dev_url` is correct
`build`:`number` is correct
Build succeeded for all architectures