### PR TITLE
Update sqlite from 3.39.0 to 3.39.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.39.0" %}
+{% set version = "3.39.2" %}
 {% set year = "2022" %}
 {% set version_split = version.split(".") %}
 {% set major = version_split[0] %}
@@ -12,7 +12,7 @@ package:
 
 source:
   url: https://www.sqlite.org/{{ year }}/sqlite-autoconf-{{ version_coded }}.tar.gz
-  sha256: e90bcaef6dd5813fcdee4e867f6b65f3c9bfd0aec0f1017f9f3bbce1e4ed09e2
+  sha256: 852be8a6183a17ba47cee0bbff7400b7aa5affd283bf3beefc34fcd088a239de
   patches:
     - expose_symbols.patch  # [win]
 


### PR DESCRIPTION
## Changes
Update version from 3.39.0 to 3.39.2.

## Package Info
Home: https://www.sqlite.org/
Source: https://sqlite.org/src/dir?ci=version-3.39.2&type=tree
Changelog: https://www.sqlite.org/changes.html
Bug Tracker: https://www.sqlite.org/src/rptview?rn=1
Downloads: 4447681
Last upload: 1 day and 18 hours ago

## Verifications
License is SPDX compliant
`doc_url` is correct
`dev_url` is correct
`build`:`number` is correct
Build succeeded for all architectures

## Notes

This update was made to address several issues/regressions present in 3.39.0. There is also a new CVE (CVE-2022-35737) for `sqlite`, however, our package is unaffected as we do not compile with `-DSQLITE_ENABLE_STAT4` (see https://sqlite.org/forum/forumpost/3607259d3c).