### PR TITLE
sqlite 3.40.0 b1: Fix safe mode authorizer callback to reject disallowed UDFs

### DIFF
--- a/recipe/0001-Fix-safe-mode-authorizer-callback-to-reject-disallowed-UDFs.patch
+++ b/recipe/0001-Fix-safe-mode-authorizer-callback-to-reject-disallowed-UDFs.patch
@@ -1,0 +1,34 @@
+From 840fef1bd48ffb0dd407ad263dd1f575d96dd231 Mon Sep 17 00:00:00 2001
+From: Serhii Kupriienko <skupriienko@anaconda.com>
+Date: Fri, 16 Dec 2022 14:27:05 +0200
+Subject: [PATCH] Fix -safe cli
+
+---
+ shell.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/shell.c b/shell.c
+index 6280ebf..a6a83c7 100644
+--- a/shell.c
++++ b/shell.c
+@@ -16275,7 +16275,7 @@ static int safeModeAuth(
+     "zipfile",
+     "zipfile_cds",
+   };
+-  UNUSED_PARAMETER(zA2);
++  UNUSED_PARAMETER(zA1);
+   UNUSED_PARAMETER(zA3);
+   UNUSED_PARAMETER(zA4);
+   switch( op ){
+@@ -16290,7 +16290,7 @@ static int safeModeAuth(
+     case SQLITE_FUNCTION: {
+       int i;
+       for(i=0; i<ArraySize(azProhibitedFunctions); i++){
+-        if( sqlite3_stricmp(zA1, azProhibitedFunctions[i])==0 ){
++        if( sqlite3_stricmp(zA2, azProhibitedFunctions[i])==0 ){
+           failIfSafeMode(p, "cannot use the %s() function in safe mode",
+                          azProhibitedFunctions[i]);
+         }
+-- 
+2.34.1
+

--- a/recipe/0001-Fix-safe-mode-authorizer-callback-to-reject-disallowed-UDFs.patch
+++ b/recipe/0001-Fix-safe-mode-authorizer-callback-to-reject-disallowed-UDFs.patch
@@ -1,5 +1,5 @@
 From 840fef1bd48ffb0dd407ad263dd1f575d96dd231 Mon Sep 17 00:00:00 2001
-From: Serhii Kupriienko <skupriienko@anaconda.com>
+From: Serhii Kupriienko
 Date: Fri, 16 Dec 2022 14:27:05 +0200
 Subject: [PATCH] Fix -safe cli
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,9 +15,10 @@ source:
   sha256: 0333552076d2700c75352256e91c78bf5cd62491589ba0c69aed0a81868980e7
   patches:
     - expose_symbols.patch  # [win]
+    - 0001-Fix-safe-mode-authorizer-callback-to-reject-disallowed-UDFs.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # sometimes adds new symbols.  Default behavior is OK.
     #    https://abi-laboratory.pro/tracker/timeline/sqlite/
@@ -31,6 +32,7 @@ requirements:
     - make      # [not win]
     - libtool   # [not win]
     - m2-patch  # [win]
+    - patch     # [not win]
   host:
     - ncurses   # [not win]
     - readline  # [not win]
@@ -50,6 +52,14 @@ test:
     - if not exist %PREFIX%\\Library\include\sqlite3ext.h exit 1  # [win]
     - test -f $PREFIX/include/sqlite3.h                           # [not win]
     - test -f $PREFIX/include/sqlite3ext.h                        # [not win]
+    # 2022-12-16: Test if --safe does not prevent writefile() and readfile()
+    # Remove it when the release >=3.40.1 is out.
+    - sqlite3 --safe ":memory:" "SELECT writefile('secret.txt', randomblob(5))" || true  # [not win]
+    - sqlite3 --safe ":memory:" "SELECT readfile('secret.txt')" || true                  # [not win]
+    - cat secret.txt || true                                                             # [not win]
+    - sqlite3 --safe ":memory:" "SELECT writefile('secret.txt', randomblob(5))" || cmd /K "exit /b 0"  # [win]
+    - sqlite3 --safe ":memory:" "SELECT readfile('secret.txt')" || cmd /K "exit /b 0"                  # [win]
+    - cat secret.txt  || cmd /K "exit /b 0"                                                            # [win]
 
 about:
   home: https://www.sqlite.org/


### PR DESCRIPTION
To address the CVE-2022-46908 (a **critical** base score - **9.8**).


Actions:
1. Bump the build number to `1`
2. Add `patch  # [not win]` to `requirements/build`
3. Add a patch to fix safe mode authorizer callback to reject disallowed UDFs:
 - NVD https://nvd.nist.gov/vuln/detail/CVE-2022-46908
 - the issue https://sqlite.org/forum/forumpost/07beac8056151b2f
 - the the upstream commit https://sqlite.org/src/vinfo/cefc032473ac5ad2?diff=1
 4. Add the test commands from here https://sqlite.org/forum/forumpost/07beac8056151b2f?raw to check if the `writefile()` and `readfile()` doesn't work with the `--safe` flag

Note:
- As we download the C source code as an [amalgamation](https://sqlite.org/amalgamation.html) from here https://sqlite.org/2022/sqlite-autoconf-3400000.tar.gz I applied a patch to the file `shell.c` of this amalgamation (not the upstream `src/shell.c.in` https://sqlite.org/src/file?name=src/shell.c.in&ci=trunk
