### PR TITLE
sqlite 3.51.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,9 +29,9 @@ requirements:
     - {{ stdlib('c') }}
     - make      # [not win]
   host:
-    - ncurses 6.4            # [not win]
-    - readline >=8.2,<9.0a0  # [not win]
-    - zlib 1.2               # [not win]
+    - ncurses {{ ncurses }}    # [not win]
+    - readline {{ readline }}  # [not win]
+    - zlib {{ zlib }}          # [not win]
   run:
     - {{ pin_compatible('ncurses') }}   # [not win]
     - {{ pin_compatible('readline') }}  # [not win]
@@ -39,9 +39,11 @@ requirements:
 
 test:
   requires:
+    - python
     - binutils  # [linux]
   commands:
     - sqlite3 --version
+    - python -c "import sqlite3; print(sqlite3.sqlite_version)"
     - if not exist %PREFIX%\\Library\bin\sqlite3.exe exit 1       # [win]
     - if not exist %PREFIX%\\Library\bin\sqlite3.dll exit 1       # [win]
     - if not exist %PREFIX%\\Library\lib\sqlite3.lib exit 1       # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.50.2" %}
+{% set version = "3.51.0" %}
 {% set year = "2025" %}
 {% set version_split = version.split(".") %}
 {% set major = version_split[0] %}
@@ -12,12 +12,12 @@ package:
 
 source:
   url: https://www.sqlite.org/{{ year }}/sqlite-autoconf-{{ version_coded }}.tar.gz
-  sha256: 84a616ffd31738e4590b65babb3a9e1ef9370f3638e36db220ee0e73f8ad2156
+  sha256: 42e26dfdd96aa2e6b1b1be5c88b0887f9959093f650d693cb02eb9c36d146ca5
   patches:
     - expose_symbols.patch  # [win]
 
 build:
-  number: 1
+  number: 0
   run_exports:
     # sometimes adds new symbols.  Default behavior is OK.
     #    https://abi-laboratory.pro/tracker/timeline/sqlite/
@@ -28,12 +28,10 @@ requirements:
     - {{ compiler('c') }}
     - {{ stdlib('c') }}
     - make      # [not win]
-    - m2-patch  # [win]
   host:
-    - ncurses 6.4  # [not win]
-    - readline 8.0  # [not ((linux and aarch64) or (osx and arm64) or win)]
-    - readline 8.1  # [(linux and aarch64) or (osx and arm64)]
-    - zlib 1.2  # [not win]
+    - ncurses 6.4            # [not win]
+    - readline >=8.2,<9.0a0  # [not win]
+    - zlib 1.2               # [not win]
   run:
     - {{ pin_compatible('ncurses') }}   # [not win]
     - {{ pin_compatible('readline') }}  # [not win]
@@ -59,7 +57,7 @@ test:
     - readelf -d $PREFIX/lib/libsqlite3${SHLIB_EXT} | grep SONAME # [linux]
 
 about:
-  home: https://www.sqlite.org/
+  home: https://www.sqlite.org
   license: blessing
   license_file: LICENSE.md
   license_family: Other


### PR DESCRIPTION
sqlite 3.51.0

**Destination channel:** Defaults

### Links

[PKG-10547]
Project Feedstock URL: https://github.com/AnacondaRecipes/sqlite-feedstock
Project Home URL: https://www.sqlite.org/
Project Dev URL: https://sqlite.org/src/dir?ci=trunk

### Explanation of changes:

- version bumped 3.50.2 → 3.51.0
- dropped explicit host versions in favor of templated pins from cbc.yaml for ncurses/readline/zlib


[PKG-10547]: https://anaconda.atlassian.net/browse/PKG-10547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ