### PR TITLE
Also enable SQLITE_ENABLE_UNLOCK_NOTIFY on windows.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -11,6 +11,7 @@ cl ^
     /DSQLITE_ENABLE_COLUMN_METADATA=1 ^
     /DSQLITE_MAX_VARIABLE_NUMBER=250000 ^
     /DSQLITE_ENABLE_FTS5 ^
+    /DSQLITE_ENABLE_UNLOCK_NOTIFY ^
     shell.c sqlite3.c -Fesqlite3.exe ^
     /DSQLITE_EXPORTS
 
@@ -22,6 +23,7 @@ cl ^
     /DSQLITE_MAX_VARIABLE_NUMBER=250000 ^
     /DSQLITE_ENABLE_JSON1 ^
     /DSQLITE_ENABLE_FTS5 ^
+    /DSQLITE_ENABLE_UNLOCK_NOTIFY ^
     sqlite3.c -link -dll -out:sqlite3.dll
 
 COPY sqlite3.exe  %LIBRARY_BIN% || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - expose_symbols.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   string: h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
   run_exports:
     # sometimes adds new symbols.  Default behavior is OK.


### PR DESCRIPTION
# sqlite v3.51.1 rebuild

## Changes
- Bump build number
- enable SQLITE_ENABLE_UNLOCK_NOTIFY on windows (already enabled on unix).

## Reliant PR
- https://github.com/AnacondaRecipes/vl-convert-python-feedstock/pull/3