### PR TITLE
sqlite 3.51.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
-{% set version = "3.51.1" %}
-{% set year = "2025" %}
+{% set name = "sqlite" %}
+{% set version = "3.51.2" %}
+{% set year = "2026" %}
 {% set version_split = version.split(".") %}
 {% set major = version_split[0] %}
 {% set minor = version_split[1]|int * 10 %}
@@ -7,17 +8,17 @@
 {% set version_coded=(major ~ (("%03d" % minor)|string) ~ (("%03d" % bugfix)|string)) %}
 
 package:
-  name: sqlite
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://www.sqlite.org/{{ year }}/sqlite-autoconf-{{ version_coded }}.tar.gz
-  sha256: 4f2445cd70479724d32ad015ec7fd37fbb6f6130013bd4bfbc80c32beb42b7e0
+  url: https://www.sqlite.org/{{ year }}/{{ name }}-autoconf-{{ version_coded }}.tar.gz
+  sha256: fbd89f866b1403bb66a143065440089dd76100f2238314d92274a082d4f2b7bb
   patches:
     - expose_symbols.patch  # [win]
 
 build:
-  number: 1
+  number: 0
   string: h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
   run_exports:
     # sometimes adds new symbols.  Default behavior is OK.


### PR DESCRIPTION
sqlite 3.51.2 

**Destination channel:** Defaults

### Links

- [PKG-12667]
- dev_url:        https://sqlite.org/src/dir?ci=trunk
- conda_forge:    https://github.com/conda-forge/sqlite-feedstock
- pypi:           https://pypi.org/project/sqlite/3.51.2
- pypi inspector: https://inspector.pypi.io/project/sqlite/3.51.2

### Explanation of changes:

- new version number


[PKG-12667]: https://anaconda.atlassian.net/browse/PKG-12667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ