### PR TITLE
sqlite 3.53.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sqlite" %}
-{% set version = "3.51.2" %}
+{% set version = "3.53.2" %}
 {% set year = "2026" %}
 {% set version_split = version.split(".") %}
 {% set major = version_split[0] %}
@@ -13,7 +13,7 @@ package:
 
 source:
   url: https://www.sqlite.org/{{ year }}/{{ name }}-autoconf-{{ version_coded }}.tar.gz
-  sha256: fbd89f866b1403bb66a143065440089dd76100f2238314d92274a082d4f2b7bb
+  sha256: 588ad51949419a56ebe81fe56193d510c559eb94c9a57748387860b5d3069316
   patches:
     - expose_symbols.patch  # [win]
 


### PR DESCRIPTION
**Destination channel:** Defaults

### Links

- [PKG-15153](https://anaconda.atlassian.net/browse/PKG-15153)
- dev_url:        https://sqlite.org/src/dir?udc=1&ci=branch-3.53
- conda_forge:    https://github.com/conda-forge/sqlite-feedstock

### Explanation of changes:

- new version number

### Security changes 3.51.2 -> 3.53.2
- security fixes: CVE-2026-11824, CVE-2026-11822 (FTS5 heap buffer overflows, CVSS 7.8)
- WAL-reset database corruption fix (3.53.0)

[PKG-15153]: https://anaconda.atlassian.net/browse/PKG-15153